### PR TITLE
slug bug fix

### DIFF
--- a/src/app/[...slug]/page.js
+++ b/src/app/[...slug]/page.js
@@ -59,8 +59,14 @@ export async function generateStaticParams() {
 
     const pages = dataPages.data.map((page) => {
       let fullSlug = page.Slug;
-      if (page.parent_page) {
-        fullSlug = `${page.parent_page.URL}/${page.Slug}`;
+      if (page.parent_page?.URL) {
+        // Clean up URLs by removing leading/trailing slashes
+        const parentUrl = page.parent_page.URL.replace(/^\/+|\/+$/g, '');
+        const pageSlug = page.Slug.replace(/^\/+|\/+$/g, '');
+        fullSlug = `${parentUrl}/${pageSlug}`;
+      } else {
+        // Clean up single slug
+        fullSlug = fullSlug.replace(/^\/+|\/+$/g, '');
       }
       return { slug: fullSlug.split("/") };
     });
@@ -167,7 +173,9 @@ export default async function Page({ params }) {
       slugArray.length > 1 ? slugArray.slice(0, -1).join("/") : null;
 
     if (parentSlug) {
-      apiUrl = `${strapiURL}/api/pages?filters[Slug][$eq]=${childSlug}&filters[parent_page][URL][$eq]=/${parentSlug}&populate=*`;
+      // Clean up parent slug before using in API call
+      const cleanParentSlug = parentSlug.replace(/^\/+|\/+$/g, '');
+      apiUrl = `${strapiURL}/api/pages?filters[Slug][$eq]=${childSlug}&filters[parent_page][URL][$eq]=/${cleanParentSlug}&populate=*`;
     } else {
       apiUrl = `${strapiURL}/api/pages?filters[Slug][$eq]=${childSlug}&populate=*`;
     }

--- a/src/app/[...slug]/page.js
+++ b/src/app/[...slug]/page.js
@@ -21,7 +21,7 @@ export async function generateStaticParams() {
 
   try {
     const resPages = await fetch(
-      `${strapiURL}/api/pages?fields[]=Slug&pagination[limit]=1000&populate=parent`,
+      `${strapiURL}/api/pages?fields[]=Slug&pagination[limit]=1000&populate=parent_page`,
       { next: { revalidate: 60 } }
     );
     const resAttorneys = await fetch(
@@ -59,8 +59,8 @@ export async function generateStaticParams() {
 
     const pages = dataPages.data.map((page) => {
       let fullSlug = page.Slug;
-      if (page.parent) {
-        fullSlug = `${page.parent.url}/${page.Slug}`;
+      if (page.parent_page) {
+        fullSlug = `${page.parent_page.URL}/${page.Slug}`;
       }
       return { slug: fullSlug.split("/") };
     });
@@ -167,7 +167,7 @@ export default async function Page({ params }) {
       slugArray.length > 1 ? slugArray.slice(0, -1).join("/") : null;
 
     if (parentSlug) {
-      apiUrl = `${strapiURL}/api/pages?filters[Slug][$eq]=${childSlug}&filters[parent][URL][$eq]=/${parentSlug}&populate=*`;
+      apiUrl = `${strapiURL}/api/pages?filters[Slug][$eq]=${childSlug}&filters[parent_page][URL][$eq]=/${parentSlug}&populate=*`;
     } else {
       apiUrl = `${strapiURL}/api/pages?filters[Slug][$eq]=${childSlug}&populate=*`;
     }

--- a/src/app/[...slug]/page.module.css
+++ b/src/app/[...slug]/page.module.css
@@ -28,7 +28,7 @@
 
 .Descriptionsection {
   background-color: #ece7e7;
-  padding-top: 4rem;
+  padding-top: 10rem;
   padding-bottom: 4rem;
 }
 .DescriptionTitle {

--- a/src/app/components/Footer/Footer.js
+++ b/src/app/components/Footer/Footer.js
@@ -55,24 +55,23 @@ export default function Footer() {
   // Helper function to construct proper URL based on page data
   const constructUrl = (page, parentSection) => {
     if (!page) return '/';
-    console.log('Constructing URL for page:', page);
-    console.log('Parent section:', parentSection);
 
-    // Get the parent URL from the section
-    const parentUrl = parentSection?.URL || '';
-    const pageSlug = page.Slug || '';
+    // Get the parent URL and page slug, removing any leading/trailing slashes
+    const parentUrl = (parentSection?.URL || '').replace(/^\/+|\/+$/g, '');
+    const pageSlug = (page.Slug || '').replace(/^\/+|\/+$/g, '');
 
-    console.log('Parent URL:', parentUrl, 'Page Slug:', pageSlug);
-
-    // Clean up URLs and construct the final URL
-    const cleanParentUrl = parentUrl.replace(/^\/+|\/+$/g, '');
-    const cleanPageSlug = pageSlug.replace(/^\/+|\/+$/g, '');
-
-    if (cleanParentUrl && cleanPageSlug) {
-      return `/${cleanParentUrl}/${cleanPageSlug}`;
+    // Construct the URL ensuring no double slashes
+    if (parentUrl && pageSlug) {
+      return `/${parentUrl}/${pageSlug}`;
     }
 
-    return cleanPageSlug ? `/${cleanPageSlug}` : '/';
+    // If only pageSlug exists
+    if (pageSlug) {
+      return `/${pageSlug}`;
+    }
+
+    // Default to homepage
+    return '/';
   };
 
   // Toggle section expansion


### PR DESCRIPTION
Update so far for bug fix:

1. Static Path Generation Fix
    * Cleaned up URL formatting in generateStaticParams
    * Removed leading/trailing slashes from parent URLs and page slugs
    * Fixed path combination logic to prevent double slashes
2. Static Path Generation Fix
    * Added proper cleanup of parent slug before API calls
    * Ensured single leading slash in parent_page[URL] filter
    * Format: api/pages?filters[Slug][$eq]=childSlug&filters[parent_page][URL][$eq]=/parentSlug
3. URL Pattern Cleanup
    * Removed all instances of double slashes (//)
    * Standardized URL format to /parent/child
    * Applied consistent slash handling across all URL generations
4. Build Error Resolution
    * Fixed "Requested and resolved page mismatch" error
    * Ensured consistent path formatting during static generation
    * Properly handled URL construction for Next.js routing
